### PR TITLE
fix: poetry deprecation warning

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /docs
 # Initialize project
 RUN echo "MKDOCS_ENV: "${MKDOCS_ENV} && \
     poetry install \
-    $(if [ "$MKDOCS_ENV" = 'production' ]; then echo '--no-dev'; fi) \
+    $(if [ "$MKDOCS_ENV" = 'production' ]; then echo '--only main'; fi) \
     --no-interaction --no-ansi && \
     if [ "$MKDOCS_ENV" = 'production' ]; then rm -rf "$POETRY_CACHE_DIR"; fi
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -41,7 +41,7 @@ WORKDIR /docs
 # Initialize project
 RUN echo "MKDOCS_ENV: "${MKDOCS_ENV} && \
     poetry install \
-    $(if [ "$MKDOCS_ENV" = 'production' ]; then echo '--no-dev'; fi) \
+    $(if [ "$MKDOCS_ENV" = 'production' ]; then echo '--only main'; fi) \
     --no-interaction --no-ansi && \
     if [ "$MKDOCS_ENV" = 'production' ]; then rm -rf "$POETRY_CACHE_DIR"; fi
 


### PR DESCRIPTION
When running `docker build` a warning suggests to update the poetry parameter

```
MKDOCS_ENV: production
Skipping virtualenv creation, as specified in config file.
The `--no-dev` option is deprecated, use the `--only main` notation instead.
```