### PR TITLE
Install python package setuptools

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -31,12 +31,14 @@ RUN apk add --no-cache \
 
 # Copy only requirements to cache them in docker layer
 COPY poetry.lock pyproject.toml /docs/
+COPY requirements.txt /
 
 # Set working directory
 WORKDIR /docs
 
 # Initialize project
 RUN echo "MKDOCS_ENV: "${MKDOCS_ENV} && \
+    pip3 install --requirement /requirements.txt --no-cache-dir --root-user-action ignore && \
     poetry install \
     $(if [ "$MKDOCS_ENV" = 'production' ]; then echo '--only main'; fi) \
     --no-interaction --no-ansi && \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -34,12 +34,14 @@ RUN apt-get update && \
 
 # Copy only requirements to cache them in docker layer
 COPY poetry.lock pyproject.toml /docs/
+COPY requirements.txt /
 
 # Set working directory
 WORKDIR /docs
 
 # Initialize project
 RUN echo "MKDOCS_ENV: "${MKDOCS_ENV} && \
+    pip3 install --requirement /requirements.txt --no-cache-dir --root-user-action ignore && \
     poetry install \
     $(if [ "$MKDOCS_ENV" = 'production' ]; then echo '--only main'; fi) \
     --no-interaction --no-ansi && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+setuptools==75.1.0


### PR DESCRIPTION
This should fix the failing pipeline #240 where recent python docker images are used.

In the latest python docker images the setuptools python package is removed. But this package seems to be required to run poetry successfully.